### PR TITLE
Add error handling to !p and !a commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,12 @@ discord.on("message", (msg) => {
 				}, k*5000);
 			});
 		} else if( mc[0] == "a" && mc.length >= 2 ){
-			steam.addFriend(mc[1]);
+			try{
+				steam.addFriend(mc[1]);
+			} catch (err){
+				msg.reply("that's not a valid Steam ID!");
+				return;
+			}
 			webhook.send("Added friend", { username: "Steam Friends", avatarURL: "https://eet.li/7fd7e03.png" });
 		} else if( mc[0] == "f" ) {
 			var friends = Object.keys(steam.myFriends);

--- a/index.js
+++ b/index.js
@@ -68,7 +68,11 @@ discord.on("message", (msg) => {
 		var mc = msg.content.slice(1).split(" ");
 
 		if( mc[0] == "p" && mc.length >= 3 ){
-			steam.chatMessage(mc[1], mc.slice(2).join(" "));
+			try{
+				steam.chatMessage(mc[1], mc.slice(2).join(" "));
+			} catch (err){
+				msg.reply("that's not a valid Steam ID!");
+			}
 		} else if( mc[0] == "r" && mc.length >= 2 ){
 			mc.slice(1).forEach(function(v,k){
 				setTimeout(function(){


### PR DESCRIPTION
Currently, `!p` and `!a` will crash Steamcord when passed invalid SteamIDs. This is just a quick fix to ensure that doesn't happen.