### PR TITLE
Display Blocked if a user is blocked in !f output

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ discord.on("message", (msg) => {
 							else states.push("Offline");
 						} else {
 							if( steam.myFriends[id] == Steam.Steam.EFriendRelationship.RequestRecipient ) states.push("Added you as a friend");
+							else if ( steam.myFriends[id] == Steam.Steam.EFriendRelationship.Ignored ) states.push("Blocked");
 							else states.push("??");
 						}
 					});


### PR DESCRIPTION
Perhaps these entries should be removed entirely, but it may be useful to see who is blocked, even if the username is unreadable.