### PR TITLE
Send message attachments to Steam using cdn.discordapp.com URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,10 @@ discord.on("message", (msg) => {
 			msg.reply("??");
 		}
 	} else {
-		if( msg.channel.name != "general" ) steam.chatMessage(msg.channel.name, msg.content);
+		if( msg.channel.name != "general" ) {
+			let attachmentsStr = msg.attachments.reduce((acc, attachment) => (acc + "\n" + attachment.url), "");
+			steam.chatMessage(msg.channel.name, msg.content + attachmentsStr);
+		}
 	}
 });
 


### PR DESCRIPTION
This allows users to send screenshots or other files along and have them received (albeit without embeds) on Steam's end.

This is useful if your screenshot program doesn't allow you to upload the file sharing site you've built and you can't be arsed to figure out how to make it work. :^)