### PR TITLE
Only send Steam a typing start event if the user is typing

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,6 +401,7 @@ discord.on("message", (msg) => {
 
 discord.on("typingStart", (chan, user) => {
 	if( chan.name == "general" ) return;
+	if( user.id !== settings.discord.master ) return;
 
 	steam.chatTyping(chan.name);
 });


### PR DESCRIPTION
Avoids others freaking out over being stalked when the user appears to begin typing as soon as the other person starts (I speak from experience).

~~Where's my number one contributor badge? <3~~